### PR TITLE
chore(assets): deprecate logo_telegram-sign-box_s

### DIFF
--- a/src/shared/config/deprecated-logos.json
+++ b/src/shared/config/deprecated-logos.json
@@ -6,5 +6,9 @@
     "logo_alfa-bank-sing-square_m_white": {
         "replacement": "logo_alfa-bank-sign-square_m_white",
         "date": "04.25"
+    },
+    "logo_telegram-sign-box_s": {
+        "replacement": "logo_telegram-sign-circle_s",
+        "date": "07.26"
     }
 }


### PR DESCRIPTION
## Summary
- В `deprecated-logos.json` помечен `logo_telegram-sign-box_s` с заменой на `logo_telegram-sign-circle_s` (07.26), размер S.

## Test plan
- [ ] На [icons-demo](https://core-ds.github.io/icons-demo/) у deprecated-логотипа отображается замена

Made with [Cursor](https://cursor.com)